### PR TITLE
Fix/snyk-vulnerabilities

### DIFF
--- a/java/.snyk
+++ b/java/.snyk
@@ -9,3 +9,7 @@ ignore:
         - '*':
             reason: Use of the library is consistent with commercial use as we are not making changes, only consuming it as part of commercial work.
             expires: '2030-01-01T00:00:00.000Z'
+    SNYK:LIC:MAVEN:JUNIT:JUNIT:EPL-1.0:
+        - '*':
+            reason: Use of the library is consistent with commercial use as we are not making changes, only consuming it as part of commercial work.
+            expires: '2030-01-01T00:00:00.000Z'

--- a/java/.snyk
+++ b/java/.snyk
@@ -1,0 +1,11 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.14.0
+ignore: 
+    snyk:lic:maven:ch.qos.logback:logback-classic:EPL-1.0_OR_LGPL-2.1:
+        - '*':
+            reason: Use of the library is consistent with commercial use as we are not making changes, only consuming it as part of commercial work.
+            expires: '2030-01-01T00:00:00.000Z'
+    snyk:lic:maven:ch.qos.logback:logback-core:EPL-1.0_OR_LGPL-2.1:
+        - '*':
+            reason: Use of the library is consistent with commercial use as we are not making changes, only consuming it as part of commercial work.
+            expires: '2030-01-01T00:00:00.000Z'

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.amido.stacks.modules</groupId>
         <artifactId>stacks-modules-parent</artifactId>
-        <version>1.0.0-RC3</version>
+        <version>1.0.0-RC4</version>
     </parent>
 
     <artifactId>stacks-azure-servicebus</artifactId>
@@ -17,6 +16,7 @@
 
     <properties>
         <com.amido.stacks-core-messaging.version>1.0.0</com.amido.stacks-core-messaging.version>
+        <!-- <logback.version>1.2.6</logback.version> -->
     </properties>
 
     <repositories>
@@ -49,6 +49,20 @@
             <groupId>com.amido.stacks.modules</groupId>
             <artifactId>stacks-core-messaging</artifactId>
             <version>${com.amido.stacks-core-messaging.version}</version>
+        </dependency>
+
+        <!-- https://snyk.io/vuln/SNYK-JAVA-IONETTY-1584064 -->
+        <!-- https://snyk.io/vuln/SNYK-JAVA-IONETTY-1584063 -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>${io.netty.netty-codec-http.version}</version>
+        </dependency>
+
+        <!-- https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327 -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
ignore
    SNYK:LIC:MAVEN:JUNIT:JUNIT:EPL-1.0:
        - '*':
            reason: Use of the library is consistent with commercial use as we are not making changes, only consuming it as part of commercial work.
            expires: '2030-01-01T00:00:00.000Z'